### PR TITLE
PrivacyInfo.xcprivacy を追加

### DIFF
--- a/memory_info/ios/Resources/PrivacyInfo.xcprivacy
+++ b/memory_info/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/memory_info/ios/memory_info.podspec
+++ b/memory_info/ios/memory_info.podspec
@@ -16,6 +16,7 @@ Get device memory info(ram&rom)
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
+  s.resource_bundles = {'memory_info_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## What does this change?
Privacy Manifests の [Required Reason API への対応状況を解析するツール](https://github.com/crasowas/app_store_required_privacy_manifest_analyser) で解析したところ、
[memory_info](https://pub.dev/packages/memory_info) で DiskSpace に関する API を利用している箇所があるにも関わらず、PrivacyInfo.xcprivacy ファイルが無いことがわかりました 
[memory_info](https://pub.dev/packages/memory_info)  は 1 年以上管理されておらず Privacy Manifests 対応を依頼しても望み薄なので、
https://github.com/MaikuB/flutter_local_notifications/pull/2221 を参考に PrivacyInfo.xcprivacy を追加しました

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397 より、 
使用理由は `85F4.1` にしています。

```
# 原文
Declare this reason to display disk space information to the person using the device. Disk space may be displayed in units of information (such as bytes) or units of time combined with a media type (such as minutes of HD video).

Information accessed for this reason, or any derived information, may not be sent off-device. There is an exception that allows the app to send disk space information over the local network to another device operated by the same person only for the purpose of displaying disk space information on that device; this exception only applies if the user has provided explicit permission to send disk space information, and the information may not be sent over the Internet.

# 日本語訳
デバイスを使用する人にディスク容量情報を表示するために、この理由を宣言する。ディスク容量は、情報単位（バイトなど）またはメディアタイプと組み合わされた時間単位（HDビデオの分単位など）で表示することができる。

このような理由でアクセスされた情報、または派生する情報は、デバイス外に送信することはできません。この例外は、ディスク容量情報を送信するための明示的な許可をユーザーが提供した場合にのみ適用され、情報はインターネット経由で送信することはできません。
``` 