### PR TITLE
Added PrivacyInfo.xcprivacy for NSPrivacyAccessedAPICategoryDiskSpace

### DIFF
--- a/memory_info/ios/Resources/PrivacyInfo.xcprivacy
+++ b/memory_info/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/memory_info/ios/memory_info.podspec
+++ b/memory_info/ios/memory_info.podspec
@@ -16,6 +16,7 @@ Get device memory info(ram&rom)
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
+  s.resource_bundles = {'memory_info_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## What does this change?

Fix. https://github.com/MrOlolo/memory_info/issues/5

## Re-analyzed result

```
Analyzing memory_info ...
💡 Found privacy manifest file(s): 1
[0] /Users/a13931/.pub-cache/git/memory_info-90226641b9d1c56ea14dd6ba0dd856d995f595a6/memory_info/ios/Resources/PrivacyInfo.xcprivacy
API usage analysis result(s): 1
[0] NSPrivacyAccessedAPICategoryDiskSpace:volumeAvailableCapacityForImportantUsageKey,systemFreeSize,systemSize:/Users/a13931/.pub-cache/git/memory_info-90226641b9d1c56ea14dd6ba0dd856d995f595a6/memory_info/ios/Classes/MemoryInfo/MemoryInfo.swift
✅ All required API reasons have been described in the privacy manifest.
```